### PR TITLE
Add a regression test for GitHub issue #252

### DIFF
--- a/tests/scripts/teardown_irods.sh
+++ b/tests/scripts/teardown_irods.sh
@@ -6,14 +6,16 @@
 
 E_ARGS_MISSING=3
 
-in_path=$1
+owner="$1"
+in_path="$2"
 
-if [[ $# < 1 ]]
+if [[ $# < 2 ]]
 then
-    echo "Insufficient command line arguments; expected 1"
+    echo "Insufficient command line arguments; expected 2"
     exit $E_ARGS_MISSING
 fi
 
-irm -rf $in_path
+ichmod -r own "$owner" "$in_path"
+irm -rf "$in_path"
 
 exit


### PR DESCRIPTION
Add a regression test for this segfault, which is known to occur on
iRODS 4.2.7. iRODS 4.2.10 fixes a server bug which prevents this baton
bug being triggered.

Improve the robustness of the iRODS teardown script by adding an
ichmod to ensure all test data are owned (and deletable) by the
current user before attempting to delete.